### PR TITLE
feat(script/build): updated context build logic

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -45,7 +45,7 @@ if (await exists('./src/server')) {
 
 const buildCmd = production ? esbuild.build : esbuild.context;
 
-for (const context of ['client', 'server']) {
+for (const context of environments) {
   buildCmd({
     bundle: true,
     entryPoints: [`./src/${context}/index.ts`],


### PR DESCRIPTION
* Sometimes the resource may not have the server directory, because it's a client only resource in this case the build script will throw an error. Using this approach build script will only build directories which are present.