### PR TITLE
Fix missing getPackage import in build.js

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,6 +1,6 @@
 import esbuild from 'esbuild';
 import { readFile, writeFile } from 'fs/promises';
-import { exists, exec, getFiles } from './utils.js';
+import { exists, exec, getFiles, getPackage } from './utils.js';
 
 /** @type {import('esbuild').BuildOptions} */
 const server = {


### PR DESCRIPTION
`pnpm watch` will not work without this imported, and probably the build wont either.

Fixes the missing import for this function https://github.com/overextended/fivem-typescript-boilerplate/blob/main/scripts/build.js#L19