### PR TITLE
Pass version tag to build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           version: 9
 
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
       - name: Get variables
         id: get_vars
         run: |
@@ -42,7 +45,7 @@ jobs:
         run: pnpm i --frozen-lockfile
 
       - name: Run build
-        run: pnpm build
+        run: pnpm build ${{ env.RELEASE_VERSION }}
 
       - name: Bump package version
         run: |

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,6 +5,7 @@ import { createBuilder, createFxmanifest } from '@overextended/fx-utils';
 
 const watch = process.argv.includes('--watch');
 const web = await exists('./web');
+const version = process.argv.find(arg => /^v(\d+)\.(\d+)\.(\d+)$/.test(arg)) || 'custom';
 
 createBuilder(
   watch,
@@ -37,6 +38,7 @@ createBuilder(
       files: ['lib/init.lua', 'lib/client/**.lua', 'locales/*.json', 'common/data/*.json', ...files],
       dependencies: ['/server:7290', '/onesync'],
       metadata: {
+        version: version,
         ui_page: 'dist/web/index.html',
       },
     });


### PR DESCRIPTION
Added into the build script an argument check for the version (v0.0.0 format) to add into the fxmanifest.
Also integrated that system into the release workflow so that it uses the tag as the new version for release.