### PR TITLE
fix(build): add node version to manifest

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -46,6 +46,7 @@ createBuilder(
       dependencies: ['/server:13068', '/onesync'],
       metadata: {
         ui_page: 'dist/web/index.html',
+        node_version: '22'
       },
     });
 


### PR DESCRIPTION
simple fixes, enables node version 22 as standard since default target is node22